### PR TITLE
change linearization intro

### DIFF
--- a/_posts/2017-07-16-linearizability-testing.html
+++ b/_posts/2017-07-16-linearizability-testing.html
@@ -29,9 +29,9 @@ cst: true
     </div></div>
 
     <div class="brim"><div class="content">
-      <p class="edge">Linearizability is a property of a concurrent system allowing to reason about the operation's effects as though all operations are sequential.</p>
+      <p class="edge">Linearizability is a correctness condition for concurrent objects, in which all executions histories are equivalent to a correct sequential histories, with constraint on a wall-clock time.</p>
 
-      <p>An execution<span class="it">, a log of operations,</span> of a system is linearized if it's possible to select for each operation a unique moment after its start time but before it ended such that a sequential execution of the operations sorted by that moment has the same effect.</p>
+      <p>Linearizability requires that all the data operations appear to have executed atomically in some sequential order that is consistent with a global order (wall-clock time) of non-overlapping operations. (Hagit Attiya and Jennifer L Welch: “Sequential Consistency versus Linearizability,” ACM Transactions on Computer Systems (TOCS), volume 12, number 2, pages 91–122, May 1994. doi:10.1145/176575.176576)</p>
 
       <p>Fun fact! Linearizability is expensive in distributed systems and in multithreaded programming so both fields have relaxed models :) eventual consistency and out-of-order execution.</p>
 


### PR DESCRIPTION
The informal version of definition is taken from Hagit Attiya and Jennifer L Welch work (“Sequential Consistency versus Linearizability,” ACM Transactions on Computer Systems (TOCS), volume 12, number 2, pages 91–122, May 1994. doi:10.1145/176575.176576).

Formal one is omitted for the sake of simplicity.